### PR TITLE
Bugfix - Undeclared `self` reference

### DIFF
--- a/fetch-polyfill.js
+++ b/fetch-polyfill.js
@@ -2,9 +2,9 @@
 
 // Polyfill from https://github.com/github/fetch/blob/v1.1.1/fetch.js#L8-L21
 var support = {
-  searchParams: 'URLSearchParams' in self,
-  iterable: 'Symbol' in self && 'iterator' in Symbol,
-  blob: 'FileReader' in self && 'Blob' in self && (function() {
+  searchParams: 'URLSearchParams' in this,
+  iterable: 'Symbol' in this && 'iterator' in Symbol,
+  blob: 'FileReader' in this && 'Blob' in this && (function() {
     try {
       new Blob()
       return true
@@ -12,8 +12,8 @@ var support = {
       return false
     }
   })(),
-  formData: 'FormData' in self,
-  arrayBuffer: 'ArrayBuffer' in self
+  formData: 'FormData' in this,
+  arrayBuffer: 'ArrayBuffer' in this
 }
 
 // Polyfill from https://github.com/github/fetch/blob/v1.1.1/fetch.js#L364-L375


### PR DESCRIPTION
I made a derp before submitting when cleaning up the code.

In this file we added in the [`var support` object from `fetch`](https://github.com/github/fetch/blob/v1.1.1/fetch.js#L8-L21), which we only need one thing from: `support.blob`. I previously wrote a function `isBlobSupported`, but realized I shouldn't be making changes like this -- we should pull in things as 1-1 as possible to make maintenance straight forward.

So I undid that change, brought back in `support`, and submitted. However in doing so, I overlooked that it relied on a reference to a variable named `self`, which we don't have defined here.

This adds the `self` variable and no longer crashes.