### PR TITLE
Bugfix - Undefined self

### DIFF
--- a/fetch-polyfill.js
+++ b/fetch-polyfill.js
@@ -1,10 +1,12 @@
 'use strict';
 
+var self = this || global;
+
 // Polyfill from https://github.com/github/fetch/blob/v1.1.1/fetch.js#L8-L21
 var support = {
-  searchParams: 'URLSearchParams' in this,
-  iterable: 'Symbol' in this && 'iterator' in Symbol,
-  blob: 'FileReader' in this && 'Blob' in this && (function() {
+  searchParams: 'URLSearchParams' in self,
+  iterable: 'Symbol' in self && 'iterator' in Symbol,
+  blob: 'FileReader' in self && 'Blob' in self && (function() {
     try {
       new Blob()
       return true
@@ -12,8 +14,8 @@ var support = {
       return false
     }
   })(),
-  formData: 'FormData' in this,
-  arrayBuffer: 'ArrayBuffer' in this
+  formData: 'FormData' in self,
+  arrayBuffer: 'ArrayBuffer' in self
 }
 
 // Polyfill from https://github.com/github/fetch/blob/v1.1.1/fetch.js#L364-L375


### PR DESCRIPTION
#2 fixed an issue where `self` wasn't declared, and instead used `this`. As it turns out, when running the compiled build (not in development mode via chrome), that lead to some errors where `this` wasn't defined.

This ensures the reference works both in development and production modes on React Native by using either `this` or `global`, depending on which one exists.

The error can be seen below
![screen shot 2017-03-20 at 12 17 08 pm](https://cloud.githubusercontent.com/assets/656630/24109489/2f279dcc-0d67-11e7-863d-9e59dad7d2ae.png)


This has been verified to work in both environments, hadn't tested both in #2.  Third time's a charm...