### PR TITLE
Lower peer dependency to 0.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "timeout"
   ],
   "peerDependencies": {
-    "react-native": ">=0.31"
+    "react-native": ">=0.27"
   },
   "contributors": [{
     "name": "Atticus White",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-fetch-polyfill",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A polyfill for React Native's fetch client",
   "main": "fetch-polyfill.js",
   "scripts": {


### PR DESCRIPTION
This previously had a dependency version locked to a minimum of `0.32`. This lowers it to `0.27`, which is compatible.