### PR TITLE
Check if init exists before trying to access timeout

### DIFF
--- a/fetch-polyfill.js
+++ b/fetch-polyfill.js
@@ -40,7 +40,7 @@ export default function fetchPolyfill (input, init) {
     var xhr = new XMLHttpRequest()
 
     /* @patch: timeout */
-    if (init.timeout) {
+    if (init && init.timeout) {
       xhr.timeout = init.timeout;
     }
     /* @endpatch */


### PR DESCRIPTION
This should fix https://github.com/robinpowered/react-native-fetch-polyfill/issues/8 as it checks if `init` exists before trying to access `init.timeout`.